### PR TITLE
Implement simple CLI for policy management

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,26 @@
-# README #
+# README
 
-This README would normally document whatever steps are necessary to get your application up and running.
+This repository contains an early prototype of a Policy Management platform.
+It currently provides a simple command line interface to manage policies and
+libraries stored in a JSON file.
 
-### What is this repository for? ###
+## Usage
 
-The aim of this open source project is to provide small to medium size companies with an open-source Policy Management platform.
+Run the CLI using Python:
 
-### Incremental Development Plan ###
+```
+python -m policy_management.cli [command] [options]
+```
+
+Example:
+
+```
+python -m policy_management.cli add-library "HR"
+python -m policy_management.cli add-policy "Vacation" 1 "Take time off"
+python -m policy_management.cli list-policies
+```
+
+## Incremental Development Plan
 
 Phase 1:
  - Ability to add, edit, view and delete policies.
@@ -16,22 +30,17 @@ Phase 1:
 
 Phase 2:
  - Implement Authentication: forms authentication
- - Implement Authorization and limitedrole base access (publisher (person who can create policy) & end user (person who reads and complies ot policy)).
+ - Implement Authorization and limitedrole base access (publisher (person who can create policy) & end user (person who reads and complies to policy)).
 
 Phase 3/4 (TBC):
- - Implement Policy Sunsetting and Review: Ability to schdeule a release of a policy version.
-
-Phase 3/4 (TBC): 
+ - Implement Policy Sunsetting and Review: Ability to schedule a release of a policy version.
  - Implement test framework.
- 
+
 Phase 5:
- - Workflow: Add authentication and workflow management layer to create, update, and properly route policies. 
- 
+ - Workflow: Add authentication and workflow management layer to create, update, and properly route policies.
+
 As each of the above phases are constructed, a tick (`) will be added.
- 
+
 Known Issues/Bugs:
- 
-  
- 
-  
- 
+
+- None at this time.

--- a/policy_management/cli.py
+++ b/policy_management/cli.py
@@ -1,0 +1,144 @@
+import argparse
+from itertools import count
+from .storage import load_data, save_data
+
+
+def get_next_id(items):
+    existing_ids = {item['id'] for item in items}
+    for i in count(1):
+        if i not in existing_ids:
+            return i
+
+def add_library(name):
+    data = load_data()
+    libraries = data['libraries']
+    if any(lib['name'] == name for lib in libraries):
+        print(f"Library '{name}' already exists")
+        return
+    lib_id = get_next_id(libraries)
+    libraries.append({'id': lib_id, 'name': name})
+    save_data(data)
+    print(f"Added library {name} (id: {lib_id})")
+
+
+def list_libraries():
+    data = load_data()
+    for lib in data['libraries']:
+        print(f"{lib['id']}: {lib['name']}")
+
+
+def add_policy(title, library_id, content):
+    data = load_data()
+    policies = data['policies']
+    policy_id = get_next_id(policies)
+    policies.append({
+        'id': policy_id,
+        'title': title,
+        'library_id': library_id,
+        'content': content,
+        'version': 1
+    })
+    save_data(data)
+    print(f"Added policy {title} (id: {policy_id})")
+
+
+def list_policies():
+    data = load_data()
+    for p in data['policies']:
+        print(f"{p['id']}: {p['title']} v{p['version']} (library {p['library_id']})")
+
+
+def view_policy(pid):
+    data = load_data()
+    for p in data['policies']:
+        if p['id'] == pid:
+            print(p['title'])
+            print(f"Version: {p['version']}")
+            print(p['content'])
+            return
+    print(f"Policy {pid} not found")
+
+
+def delete_policy(pid):
+    data = load_data()
+    policies = data['policies']
+    for i, p in enumerate(policies):
+        if p['id'] == pid:
+            del policies[i]
+            save_data(data)
+            print(f"Deleted policy {pid}")
+            return
+    print(f"Policy {pid} not found")
+
+
+def edit_policy(pid, title=None, content=None, library_id=None):
+    data = load_data()
+    for p in data['policies']:
+        if p['id'] == pid:
+            if title:
+                p['title'] = title
+            if content:
+                p['content'] = content
+            if library_id is not None:
+                p['library_id'] = library_id
+            p['version'] += 1
+            save_data(data)
+            print(f"Updated policy {pid}")
+            return
+    print(f"Policy {pid} not found")
+
+
+def build_parser():
+    parser = argparse.ArgumentParser(description="Policy Management CLI")
+    sub = parser.add_subparsers(dest='cmd')
+
+    add_lib = sub.add_parser('add-library')
+    add_lib.add_argument('name')
+
+    list_lib = sub.add_parser('list-libraries')
+
+    add_p = sub.add_parser('add-policy')
+    add_p.add_argument('title')
+    add_p.add_argument('library_id', type=int)
+    add_p.add_argument('content')
+
+    list_p = sub.add_parser('list-policies')
+
+    view_p = sub.add_parser('view-policy')
+    view_p.add_argument('policy_id', type=int)
+
+    del_p = sub.add_parser('delete-policy')
+    del_p.add_argument('policy_id', type=int)
+
+    edit_p = sub.add_parser('edit-policy')
+    edit_p.add_argument('policy_id', type=int)
+    edit_p.add_argument('--title')
+    edit_p.add_argument('--content')
+    edit_p.add_argument('--library_id', type=int)
+
+    return parser
+
+
+def main(argv=None):
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if args.cmd == 'add-library':
+        add_library(args.name)
+    elif args.cmd == 'list-libraries':
+        list_libraries()
+    elif args.cmd == 'add-policy':
+        add_policy(args.title, args.library_id, args.content)
+    elif args.cmd == 'list-policies':
+        list_policies()
+    elif args.cmd == 'view-policy':
+        view_policy(args.policy_id)
+    elif args.cmd == 'delete-policy':
+        delete_policy(args.policy_id)
+    elif args.cmd == 'edit-policy':
+        edit_policy(args.policy_id, args.title, args.content, args.library_id)
+    else:
+        parser.print_help()
+
+
+if __name__ == '__main__':
+    main()

--- a/policy_management/data.json
+++ b/policy_management/data.json
@@ -1,0 +1,21 @@
+{
+  "libraries": [
+    {
+      "id": 1,
+      "name": "HR"
+    },
+    {
+      "id": 2,
+      "name": "IT"
+    }
+  ],
+  "policies": [
+    {
+      "id": 1,
+      "title": "Vacation",
+      "library_id": 1,
+      "content": "Take time off",
+      "version": 1
+    }
+  ]
+}

--- a/policy_management/storage.py
+++ b/policy_management/storage.py
@@ -1,0 +1,14 @@
+import json
+from pathlib import Path
+
+DATA_FILE = Path(__file__).resolve().parent / 'data.json'
+
+def load_data():
+    if DATA_FILE.exists():
+        with open(DATA_FILE, 'r', encoding='utf-8') as f:
+            return json.load(f)
+    return {"libraries": [], "policies": []}
+
+def save_data(data):
+    with open(DATA_FILE, 'w', encoding='utf-8') as f:
+        json.dump(data, f, indent=2)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+# No external requirements

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,42 @@
+import os
+import json
+import subprocess
+from pathlib import Path
+
+DATA_FILE = Path(__file__).resolve().parents[1] / 'policy_management' / 'data.json'
+CLI = ['python', '-m', 'policy_management.cli']
+
+
+def setup_module(module):
+    if DATA_FILE.exists():
+        DATA_FILE.unlink()
+    DATA_FILE.write_text(json.dumps({"libraries": [], "policies": []}))
+
+
+def run_cmd(args):
+    result = subprocess.run(CLI + args, capture_output=True, text=True)
+    return result.stdout.strip()
+
+
+def test_add_library_and_policy():
+    out = run_cmd(['add-library', 'HR'])
+    assert 'Added library' in out
+    out = run_cmd(['add-policy', 'Vacation', '1', 'Take time off'])
+    assert 'Added policy' in out
+    data = json.loads(DATA_FILE.read_text())
+    assert data['policies'][0]['title'] == 'Vacation'
+    assert data['libraries'][0]['name'] == 'HR'
+
+
+def test_edit_and_delete_policy():
+    run_cmd(['add-library', 'IT'])
+    run_cmd(['add-policy', 'Security', '2', 'Use antivirus'])
+    out = run_cmd(['edit-policy', '2', '--content', 'Use strong passwords'])
+    assert 'Updated policy' in out
+    data = json.loads(DATA_FILE.read_text())
+    policy = next(p for p in data['policies'] if p['id'] == 2)
+    assert policy['content'] == 'Use strong passwords'
+    out = run_cmd(['delete-policy', '2'])
+    assert 'Deleted policy' in out
+    data = json.loads(DATA_FILE.read_text())
+    assert not any(p['id'] == 2 for p in data['policies'])


### PR DESCRIPTION
## Summary
- add simple CLI to manage libraries and policies
- store data in JSON file
- provide pytest coverage
- document usage instructions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683fbcddf528832f8c8824d6c459e8b2