### PR TITLE
Add policy library filtering, history, and stats CLI commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,27 @@ Install dependencies and run tests with:
 pip install -r requirements.txt
 pytest
 ```
+
+### Command line usage ###
+
+The toolkit ships with a CLI so you can manage policies without writing code. By default
+it stores data in `policies.json` in your working directory, but you can point it anywhere
+with `--store`.
+
+```bash
+# List all policies
+python -m policy_management list
+
+# Add, update and review a policy (and put it in the "hr" library)
+python -m policy_management add 1 "Remote Work" "Initial draft" --library hr --store ./my_policies.json
+python -m policy_management edit 1 "Final content" --store ./my_policies.json
+python -m policy_management view 1 --store ./my_policies.json
+
+# Show detailed history and revert to an earlier version (recording a new version)
+python -m policy_management history 1 --store ./my_policies.json
+python -m policy_management revert 1 1 --store ./my_policies.json
+
+# Filter by library and see usage stats
+python -m policy_management list --library hr --store ./my_policies.json
+python -m policy_management stats --store ./my_policies.json
+```

--- a/policy_management/__init__.py
+++ b/policy_management/__init__.py
@@ -1,0 +1,5 @@
+"""Policy Management toolkit."""
+
+from .policy_store import FilePolicyStore, Policy, PolicyStore
+
+__all__ = ["Policy", "PolicyStore", "FilePolicyStore"]

--- a/policy_management/__main__.py
+++ b/policy_management/__main__.py
@@ -1,0 +1,7 @@
+"""Entry point for `python -m policy_management`."""
+
+from .cli import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/policy_management/cli.py
+++ b/policy_management/cli.py
@@ -1,0 +1,144 @@
+"""Command line interface for managing policies.
+
+Usage examples:
+    python -m policy_management.cli list --store policies.json
+    python -m policy_management.cli add 1 "Policy title" "Initial content" --store policies.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from .policy_store import FilePolicyStore, Policy
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Policy Management CLI")
+    store_parent = argparse.ArgumentParser(add_help=False)
+    store_parent.add_argument(
+        "--store",
+        type=Path,
+        default=Path("policies.json"),
+        help="Path to the policy store file (default: policies.json)",
+    )
+
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    add_parser = subparsers.add_parser("add", parents=[store_parent], help="Add a new policy")
+    add_parser.add_argument("policy_id", help="Unique policy identifier")
+    add_parser.add_argument("title", help="Policy title")
+    add_parser.add_argument("content", help="Policy content")
+    add_parser.add_argument("--library", help="Optional library name", default=None)
+
+    edit_parser = subparsers.add_parser(
+        "edit", parents=[store_parent], help="Edit an existing policy"
+    )
+    edit_parser.add_argument("policy_id", help="Policy identifier to edit")
+    edit_parser.add_argument("content", help="New policy content")
+
+    delete_parser = subparsers.add_parser(
+        "delete", parents=[store_parent], help="Delete a policy"
+    )
+    delete_parser.add_argument("policy_id", help="Policy identifier to delete")
+
+    view_parser = subparsers.add_parser("view", parents=[store_parent], help="View policy details")
+    view_parser.add_argument("policy_id", help="Policy identifier to view")
+
+    list_parser = subparsers.add_parser("list", parents=[store_parent], help="List all policies")
+    list_parser.add_argument("--library", help="Filter policies by library", default=None)
+
+    history_parser = subparsers.add_parser(
+        "history", parents=[store_parent], help="Show version history for a policy"
+    )
+    history_parser.add_argument("policy_id", help="Policy identifier to inspect")
+
+    revert_parser = subparsers.add_parser(
+        "revert", parents=[store_parent], help="Revert a policy to a previous version"
+    )
+    revert_parser.add_argument("policy_id", help="Policy identifier to revert")
+    revert_parser.add_argument(
+        "version_number",
+        type=int,
+        help="One-based version number to restore (a new version will be recorded)",
+    )
+
+    subparsers.add_parser(
+        "stats", parents=[store_parent], help="Show counts of policies per library"
+    )
+
+    return parser
+
+
+def _format_policy(policy: Policy) -> str:
+    version_lines = [f"  {idx + 1}: {content}" for idx, content in enumerate(policy.versions)]
+    versions_text = "\n".join(version_lines) if version_lines else "  (no versions)"
+    return (
+        f"ID: {policy.policy_id}\n"
+        f"Title: {policy.title}\n"
+        f"Library: {policy.library}\n"
+        f"Current version: {policy.content}\n"
+        f"Versions:\n{versions_text}"
+    )
+
+
+def handle_command(args: argparse.Namespace) -> int:
+    store = FilePolicyStore(args.store)
+
+    try:
+        if args.command == "add":
+            store.add_policy(args.policy_id, args.title, args.content, args.library)
+            print(f"Policy {args.policy_id} added.")
+        elif args.command == "edit":
+            store.edit_policy(args.policy_id, args.content)
+            version = len(store.view_policy(args.policy_id).versions)
+            print(f"Policy {args.policy_id} updated to version {version}.")
+        elif args.command == "delete":
+            store.delete_policy(args.policy_id)
+            print(f"Policy {args.policy_id} deleted.")
+        elif args.command == "view":
+            policy = store.view_policy(args.policy_id)
+            print(_format_policy(policy))
+        elif args.command == "list":
+            policies = store.list_policies(args.library)
+            if not policies:
+                print("No policies found.")
+            else:
+                for policy in policies:
+                    print(f"{policy.policy_id}: {policy.title} (library: {policy.library})")
+        elif args.command == "history":
+            policy = store.view_policy(args.policy_id)
+            print(_format_policy(policy))
+        elif args.command == "revert":
+            new_version = store.revert_policy(args.policy_id, args.version_number)
+            print(
+                f"Policy {args.policy_id} reverted to version {args.version_number}. "
+                f"Current version is {new_version}."
+            )
+        elif args.command == "stats":
+            policies = store.list_policies()
+            summary = store.library_summary()
+            print(f"Total policies: {len(policies)}")
+            if not policies:
+                print("No libraries found.")
+            else:
+                for library, count in sorted(summary.items()):
+                    print(f"{library}: {count}")
+        else:
+            raise ValueError(f"Unknown command: {args.command}")
+    except (ValueError, KeyError) as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return handle_command(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/policy_management/policy_store.py
+++ b/policy_management/policy_store.py
@@ -1,9 +1,16 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
 class Policy:
     """Represents a policy with version history."""
 
-    def __init__(self, policy_id: str, title: str, content: str):
+    def __init__(self, policy_id: str, title: str, content: str, library: str | None = None):
         self.policy_id = policy_id
         self.title = title
+        self.library = library or "default"
         self.content = content
         self.versions = [content]
 
@@ -12,6 +19,46 @@ class Policy:
         self.content = new_content
         self.versions.append(new_content)
 
+    def revert(self, version_number: int) -> int:
+        """Revert to a previous version and record the revert as a new version.
+
+        Args:
+            version_number: One-based index of the version to restore.
+
+        Returns:
+            The new version number after the revert is recorded.
+        """
+
+        if version_number < 1 or version_number > len(self.versions):
+            raise ValueError(
+                f"Version {version_number} is out of range for policy {self.policy_id}"
+            )
+        content_to_restore = self.versions[version_number - 1]
+        self.content = content_to_restore
+        self.versions.append(content_to_restore)
+        return len(self.versions)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "policy_id": self.policy_id,
+            "title": self.title,
+            "library": self.library,
+            "content": self.content,
+            "versions": self.versions,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, object]) -> "Policy":
+        policy = cls(
+            policy_id=str(data["policy_id"]),
+            title=str(data["title"]),
+            content=str(data["content"]),
+            library=str(data.get("library") or "default"),
+        )
+        policy.versions = list(data.get("versions", [])) or [policy.content]
+        policy.content = policy.versions[-1]
+        return policy
+
 
 class PolicyStore:
     """In-memory store for policies."""
@@ -19,10 +66,12 @@ class PolicyStore:
     def __init__(self) -> None:
         self.policies: dict[str, Policy] = {}
 
-    def add_policy(self, policy_id: str, title: str, content: str) -> None:
+    def add_policy(
+        self, policy_id: str, title: str, content: str, library: str | None = None
+    ) -> None:
         if policy_id in self.policies:
             raise ValueError(f"Policy {policy_id} already exists")
-        self.policies[policy_id] = Policy(policy_id, title, content)
+        self.policies[policy_id] = Policy(policy_id, title, content, library)
 
     def edit_policy(self, policy_id: str, new_content: str) -> None:
         if policy_id not in self.policies:
@@ -39,5 +88,60 @@ class PolicyStore:
             raise KeyError(f"Policy {policy_id} not found")
         return self.policies[policy_id]
 
-    def list_policies(self) -> list[Policy]:
-        return list(self.policies.values())
+    def list_policies(self, library: str | None = None) -> list[Policy]:
+        if library is None:
+            return list(self.policies.values())
+        return [p for p in self.policies.values() if p.library == library]
+
+    def revert_policy(self, policy_id: str, version_number: int) -> int:
+        if policy_id not in self.policies:
+            raise KeyError(f"Policy {policy_id} not found")
+        return self.policies[policy_id].revert(version_number)
+
+    def library_summary(self) -> dict[str, int]:
+        summary: dict[str, int] = {}
+        for policy in self.policies.values():
+            summary[policy.library] = summary.get(policy.library, 0) + 1
+        return summary
+
+
+class FilePolicyStore(PolicyStore):
+    """Policy store that persists data to disk."""
+
+    def __init__(self, filepath: str | Path) -> None:
+        super().__init__()
+        self.filepath = Path(filepath)
+        self._load()
+
+    def _load(self) -> None:
+        if not self.filepath.exists():
+            self.filepath.write_text(json.dumps({"policies": {}}))
+        raw = json.loads(self.filepath.read_text())
+        stored_policies = raw.get("policies", {})
+        for policy_id, policy_data in stored_policies.items():
+            self.policies[policy_id] = Policy.from_dict(policy_data)
+
+    def _save(self) -> None:
+        payload = {
+            "policies": {pid: policy.to_dict() for pid, policy in self.policies.items()}
+        }
+        self.filepath.write_text(json.dumps(payload, indent=2))
+
+    def add_policy(
+        self, policy_id: str, title: str, content: str, library: str | None = None
+    ) -> None:
+        super().add_policy(policy_id, title, content, library)
+        self._save()
+
+    def edit_policy(self, policy_id: str, new_content: str) -> None:
+        super().edit_policy(policy_id, new_content)
+        self._save()
+
+    def delete_policy(self, policy_id: str) -> None:
+        super().delete_policy(policy_id)
+        self._save()
+
+    def revert_policy(self, policy_id: str, version_number: int) -> int:
+        new_version = super().revert_policy(policy_id, version_number)
+        self._save()
+        return new_version

--- a/policy_management/tests/conftest.py
+++ b/policy_management/tests/conftest.py
@@ -1,0 +1,8 @@
+import sys
+from pathlib import Path
+
+
+# Ensure the project root is on sys.path when tests are executed without installation.
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))

--- a/policy_management/tests/test_cli.py
+++ b/policy_management/tests/test_cli.py
@@ -1,0 +1,57 @@
+import subprocess
+import sys
+from pathlib import Path
+
+
+def run_cli(args: list[str], store_path: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "policy_management.cli", *args, "--store", str(store_path)],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_cli_crud_flow(tmp_path: Path):
+    store_path = tmp_path / "cli_store.json"
+
+    add_result = run_cli(["add", "7", "CLI Policy", "initial", "--library", "hr"], store_path)
+    assert add_result.returncode == 0
+    assert "Policy 7 added." in add_result.stdout
+
+    list_result = run_cli(["list"], store_path)
+    assert list_result.returncode == 0
+    assert "7: CLI Policy (library: hr)" in list_result.stdout
+
+    list_filtered = run_cli(["list", "--library", "ops"], store_path)
+    assert "No policies found." in list_filtered.stdout
+
+    edit_result = run_cli(["edit", "7", "revised"], store_path)
+    assert edit_result.returncode == 0
+    assert "updated to version 2" in edit_result.stdout
+
+    history_result = run_cli(["history", "7"], store_path)
+    assert history_result.returncode == 0
+    assert "Versions:" in history_result.stdout
+
+    view_result = run_cli(["view", "7"], store_path)
+    assert view_result.returncode == 0
+    assert "Current version: revised" in view_result.stdout
+    assert "1: initial" in view_result.stdout
+    assert "2: revised" in view_result.stdout
+
+    revert_result = run_cli(["revert", "7", "1"], store_path)
+    assert revert_result.returncode == 0
+    assert "reverted to version 1" in revert_result.stdout
+
+    stats_result = run_cli(["stats"], store_path)
+    assert stats_result.returncode == 0
+    assert "Total policies: 1" in stats_result.stdout
+    assert "hr: 1" in stats_result.stdout
+
+    delete_result = run_cli(["delete", "7"], store_path)
+    assert delete_result.returncode == 0
+    assert "Policy 7 deleted." in delete_result.stdout
+
+    empty_result = run_cli(["list"], store_path)
+    assert "No policies found." in empty_result.stdout

--- a/policy_management/tests/test_policy_store.py
+++ b/policy_management/tests/test_policy_store.py
@@ -1,18 +1,56 @@
-from policy_management.policy_store import PolicyStore
+from pathlib import Path
+
+from policy_management.policy_store import FilePolicyStore, PolicyStore
 
 
 def test_add_edit_delete_policy():
     store = PolicyStore()
-    store.add_policy("1", "First", "content v1")
+    store.add_policy("1", "First", "content v1", library="hr")
 
     policy = store.view_policy("1")
     assert policy.title == "First"
     assert policy.content == "content v1"
+    assert policy.library == "hr"
 
     store.edit_policy("1", "content v2")
     policy = store.view_policy("1")
     assert policy.content == "content v2"
     assert policy.versions == ["content v1", "content v2"]
 
+    new_version = store.revert_policy("1", 1)
+    policy = store.view_policy("1")
+    assert new_version == 3
+    assert policy.content == "content v1"
+    assert policy.versions == ["content v1", "content v2", "content v1"]
+
     store.delete_policy("1")
     assert store.list_policies() == []
+
+
+def test_file_policy_store_persists_to_disk(tmp_path: Path):
+    store_path = tmp_path / "policies.json"
+    first_store = FilePolicyStore(store_path)
+    first_store.add_policy("42", "Persistent", "v1", library="ops")
+    first_store.edit_policy("42", "v2")
+
+    new_store = FilePolicyStore(store_path)
+    policy = new_store.view_policy("42")
+
+    assert policy.title == "Persistent"
+    assert policy.content == "v2"
+    assert policy.versions == ["v1", "v2"]
+    assert policy.library == "ops"
+
+
+def test_filter_and_library_summary():
+    store = PolicyStore()
+    store.add_policy("1", "HR", "v1", library="hr")
+    store.add_policy("2", "Ops", "v1", library="ops")
+    store.add_policy("3", "HR 2", "v1", library="hr")
+
+    assert {p.policy_id for p in store.list_policies(library="hr")} == {"1", "3"}
+    assert {p.policy_id for p in store.list_policies(library="ops")} == {"2"}
+    assert {p.policy_id for p in store.list_policies()} == {"1", "2", "3"}
+
+    summary = store.library_summary()
+    assert summary == {"hr": 2, "ops": 1}


### PR DESCRIPTION
## Summary
- add library metadata to policies with filtering and stats in the CLI
- support viewing version history and reverting policies while recording new versions
- document the new commands and extend tests to cover libraries and reverts

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69339f2a8740832f915f255a77e5cff9)