### PR TITLE
Pin pytest dependency version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pytest
+pytest==8.3.3


### PR DESCRIPTION
## Summary
- pin the pytest dependency version to ensure the lockfile specifies an exact release

## Testing
- PYTHONPATH=. pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946b3b525bc832f8c88e8f3ae36d62d)