### PR TITLE
Capture creation metadata on policies

### DIFF
--- a/policy_management/policy_store.py
+++ b/policy_management/policy_store.py
@@ -1,16 +1,52 @@
+from datetime import datetime, timezone
+
+
 class Policy:
     """Represents a policy with version history."""
 
-    def __init__(self, policy_id: str, title: str, content: str):
+    def __init__(
+        self,
+        policy_id: str,
+        title: str,
+        content: str,
+        *,
+        created_by: str | None = None,
+        created_at: datetime | None = None,
+    ):
         self.policy_id = policy_id
         self.title = title
         self.content = content
-        self.versions = [content]
+        timestamp = (created_at or datetime.now(tz=timezone.utc)).isoformat()
+        self.versions = [
+            {
+                "content": content,
+                "title": title,
+                "timestamp": timestamp,
+                "user": created_by,
+            }
+        ]
 
-    def update(self, new_content: str) -> None:
+    def update(
+        self,
+        new_content: str,
+        *,
+        title: str | None = None,
+        updated_by: str | None = None,
+        updated_at: datetime | None = None,
+    ) -> None:
         """Update policy content and track version history."""
         self.content = new_content
-        self.versions.append(new_content)
+        if title is not None:
+            self.title = title
+        timestamp = updated_at or datetime.now(tz=timezone.utc)
+        self.versions.append(
+            {
+                "content": new_content,
+                "title": self.title,
+                "timestamp": timestamp.isoformat(),
+                "user": updated_by,
+            }
+        )
 
 
 class PolicyStore:
@@ -19,15 +55,42 @@ class PolicyStore:
     def __init__(self) -> None:
         self.policies: dict[str, Policy] = {}
 
-    def add_policy(self, policy_id: str, title: str, content: str) -> None:
+    def add_policy(
+        self,
+        policy_id: str,
+        title: str,
+        content: str,
+        *,
+        created_by: str | None = None,
+        created_at: datetime | None = None,
+    ) -> None:
         if policy_id in self.policies:
             raise ValueError(f"Policy {policy_id} already exists")
-        self.policies[policy_id] = Policy(policy_id, title, content)
+        self.policies[policy_id] = Policy(
+            policy_id,
+            title,
+            content,
+            created_by=created_by,
+            created_at=created_at,
+        )
 
-    def edit_policy(self, policy_id: str, new_content: str) -> None:
+    def edit_policy(
+        self,
+        policy_id: str,
+        new_content: str,
+        *,
+        title: str | None = None,
+        updated_by: str | None = None,
+        updated_at: datetime | None = None,
+    ) -> None:
         if policy_id not in self.policies:
             raise KeyError(f"Policy {policy_id} not found")
-        self.policies[policy_id].update(new_content)
+        self.policies[policy_id].update(
+            new_content,
+            title=title,
+            updated_by=updated_by,
+            updated_at=updated_at,
+        )
 
     def delete_policy(self, policy_id: str) -> None:
         if policy_id not in self.policies:

--- a/policy_management/tests/test_policy_store.py
+++ b/policy_management/tests/test_policy_store.py
@@ -1,18 +1,48 @@
 from policy_management.policy_store import PolicyStore
 
 
+from datetime import datetime, timezone
+
+
 def test_add_edit_delete_policy():
     store = PolicyStore()
-    store.add_policy("1", "First", "content v1")
+    created_at = datetime(2023, 12, 31, 8, 0, tzinfo=timezone.utc)
+    store.add_policy(
+        "1",
+        "First",
+        "content v1",
+        created_by="author",
+        created_at=created_at,
+    )
 
     policy = store.view_policy("1")
     assert policy.title == "First"
     assert policy.content == "content v1"
+    assert policy.versions[0]["content"] == "content v1"
+    assert policy.versions[0]["title"] == "First"
+    assert policy.versions[0]["user"] == "author"
+    assert policy.versions[0]["timestamp"] == created_at.isoformat()
 
-    store.edit_policy("1", "content v2")
+    edited_at = datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc)
+    store.edit_policy(
+        "1",
+        "content v2",
+        title="First edited",
+        updated_by="admin",
+        updated_at=edited_at,
+    )
     policy = store.view_policy("1")
+    assert policy.title == "First edited"
     assert policy.content == "content v2"
-    assert policy.versions == ["content v1", "content v2"]
+    assert len(policy.versions) == 2
+
+    latest_version = policy.versions[-1]
+    assert latest_version == {
+        "content": "content v2",
+        "title": "First edited",
+        "timestamp": edited_at.isoformat(),
+        "user": "admin",
+    }
 
     store.delete_policy("1")
     assert store.list_policies() == []


### PR DESCRIPTION
## Summary
- allow policies to record creator and creation timestamp when added, storing metadata in the initial version entry
- pass creation metadata through `PolicyStore.add_policy` so the policy history captures authorship details
- extend policy store tests to assert creation metadata is preserved alongside update history

## Testing
- PYTHONPATH=. pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946b77a904c832f87c43125bf39e8d3)