### PR TITLE
Add policy libraries to policy store

### DIFF
--- a/policy_management/policy_store.py
+++ b/policy_management/policy_store.py
@@ -30,6 +30,9 @@ class PolicyLibrary:
             raise KeyError(f"Policy {policy_id} not found in library {self.library_id}")
         del self.policies[policy_id]
 
+    def has_policy(self, policy_id: str) -> bool:
+        return policy_id in self.policies
+
     def list_policies(self) -> list[Policy]:
         return list(self.policies.values())
 
@@ -54,6 +57,9 @@ class PolicyStore:
     def delete_policy(self, policy_id: str) -> None:
         if policy_id not in self.policies:
             raise KeyError(f"Policy {policy_id} not found")
+        for library in self.libraries.values():
+            if library.has_policy(policy_id):
+                library.remove_policy(policy_id)
         del self.policies[policy_id]
 
     def view_policy(self, policy_id: str) -> Policy:

--- a/policy_management/policy_store.py
+++ b/policy_management/policy_store.py
@@ -13,11 +13,33 @@ class Policy:
         self.versions.append(new_content)
 
 
+class PolicyLibrary:
+    """Represents a collection of policies grouped under a library ID."""
+
+    def __init__(self, library_id: str):
+        self.library_id = library_id
+        self.policies: dict[str, Policy] = {}
+
+    def add_policy(self, policy: Policy) -> None:
+        if policy.policy_id in self.policies:
+            raise ValueError(f"Policy {policy.policy_id} already in library {self.library_id}")
+        self.policies[policy.policy_id] = policy
+
+    def remove_policy(self, policy_id: str) -> None:
+        if policy_id not in self.policies:
+            raise KeyError(f"Policy {policy_id} not found in library {self.library_id}")
+        del self.policies[policy_id]
+
+    def list_policies(self) -> list[Policy]:
+        return list(self.policies.values())
+
+
 class PolicyStore:
     """In-memory store for policies."""
 
     def __init__(self) -> None:
         self.policies: dict[str, Policy] = {}
+        self.libraries: dict[str, PolicyLibrary] = {}
 
     def add_policy(self, policy_id: str, title: str, content: str) -> None:
         if policy_id in self.policies:
@@ -41,3 +63,35 @@ class PolicyStore:
 
     def list_policies(self) -> list[Policy]:
         return list(self.policies.values())
+
+    def create_library(self, library_id: str) -> None:
+        if library_id in self.libraries:
+            raise ValueError(f"Library {library_id} already exists")
+        self.libraries[library_id] = PolicyLibrary(library_id)
+
+    def delete_library(self, library_id: str) -> None:
+        if library_id not in self.libraries:
+            raise KeyError(f"Library {library_id} not found")
+        del self.libraries[library_id]
+
+    def view_library(self, library_id: str) -> PolicyLibrary:
+        if library_id not in self.libraries:
+            raise KeyError(f"Library {library_id} not found")
+        return self.libraries[library_id]
+
+    def list_libraries(self) -> list[PolicyLibrary]:
+        return list(self.libraries.values())
+
+    def add_policy_to_library(self, policy_id: str, library_id: str) -> None:
+        if policy_id not in self.policies:
+            raise KeyError(f"Policy {policy_id} not found")
+        library = self.view_library(library_id)
+        library.add_policy(self.policies[policy_id])
+
+    def remove_policy_from_library(self, policy_id: str, library_id: str) -> None:
+        library = self.view_library(library_id)
+        library.remove_policy(policy_id)
+
+    def list_policies_in_library(self, library_id: str) -> list[Policy]:
+        library = self.view_library(library_id)
+        return library.list_policies()

--- a/policy_management/tests/test_policy_store.py
+++ b/policy_management/tests/test_policy_store.py
@@ -1,3 +1,5 @@
+import pytest
+
 from policy_management.policy_store import PolicyStore
 
 
@@ -40,3 +42,33 @@ def test_library_creation_and_policy_assignment():
 
     store.delete_library("lib1")
     assert store.list_libraries() == []
+
+
+def test_duplicate_library_and_policy_addition_errors():
+    store = PolicyStore()
+    store.create_library("lib1")
+    with pytest.raises(ValueError):
+        store.create_library("lib1")
+
+    store.add_policy("1", "Policy One", "content")
+    store.create_library("lib2")
+    store.add_policy_to_library("1", "lib2")
+    with pytest.raises(ValueError):
+        store.add_policy_to_library("1", "lib2")
+
+
+def test_policy_deletion_cleans_libraries():
+    store = PolicyStore()
+    store.add_policy("1", "Policy One", "content")
+    store.add_policy("2", "Policy Two", "content")
+    store.create_library("lib1")
+    store.create_library("lib2")
+
+    store.add_policy_to_library("1", "lib1")
+    store.add_policy_to_library("1", "lib2")
+    store.add_policy_to_library("2", "lib2")
+
+    store.delete_policy("1")
+
+    assert [p.policy_id for p in store.list_policies_in_library("lib1")] == []
+    assert [p.policy_id for p in store.list_policies_in_library("lib2")] == ["2"]

--- a/policy_management/tests/test_policy_store.py
+++ b/policy_management/tests/test_policy_store.py
@@ -16,3 +16,27 @@ def test_add_edit_delete_policy():
 
     store.delete_policy("1")
     assert store.list_policies() == []
+
+
+def test_library_creation_and_policy_assignment():
+    store = PolicyStore()
+    store.add_policy("1", "Policy One", "content a")
+    store.add_policy("2", "Policy Two", "content b")
+
+    store.create_library("lib1")
+    libraries = store.list_libraries()
+    assert len(libraries) == 1
+    assert libraries[0].library_id == "lib1"
+
+    store.add_policy_to_library("1", "lib1")
+    store.add_policy_to_library("2", "lib1")
+
+    policies_in_library = store.list_policies_in_library("lib1")
+    assert {policy.policy_id for policy in policies_in_library} == {"1", "2"}
+
+    store.remove_policy_from_library("1", "lib1")
+    policies_after_removal = store.list_policies_in_library("lib1")
+    assert [policy.policy_id for policy in policies_after_removal] == ["2"]
+
+    store.delete_library("lib1")
+    assert store.list_libraries() == []


### PR DESCRIPTION
## Summary
- add a PolicyLibrary structure and library tracking to the policy store
- provide CRUD operations for libraries and assigning policies to them
- add tests covering library creation, policy membership, and listings

## Testing
- python -m pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946be9439ac832fb8eab1f7f8ee56af)