### PR TITLE
Add metadata fields and history tracking to policies

### DIFF
--- a/policy_management/policy_store.py
+++ b/policy_management/policy_store.py
@@ -1,16 +1,62 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+
 class Policy:
     """Represents a policy with version history."""
 
-    def __init__(self, policy_id: str, title: str, content: str):
+    def __init__(
+        self,
+        policy_id: str,
+        title: str,
+        content: str,
+        owner: str,
+        status: str,
+        created_at: datetime | None = None,
+        last_reviewed_at: datetime | None = None,
+    ):
         self.policy_id = policy_id
         self.title = title
         self.content = content
-        self.versions = [content]
+        self.owner = owner
+        self.status = status
+        self.created_at = created_at or datetime.utcnow()
+        self.last_reviewed_at = last_reviewed_at
+        self.versions: list[dict[str, Any]] = []
+        self._record_version()
+
+    def _record_version(self) -> None:
+        self.versions.append(
+            {
+                "content": self.content,
+                "owner": self.owner,
+                "status": self.status,
+                "created_at": self.created_at,
+                "last_reviewed_at": self.last_reviewed_at,
+            }
+        )
 
     def update(self, new_content: str) -> None:
         """Update policy content and track version history."""
         self.content = new_content
-        self.versions.append(new_content)
+        self._record_version()
+
+    def mark_reviewed(self, reviewed_at: datetime | None = None) -> None:
+        """Mark policy as reviewed and track history."""
+        self.last_reviewed_at = reviewed_at or datetime.utcnow()
+        self._record_version()
+
+    def change_owner(self, new_owner: str) -> None:
+        """Change policy owner and track history."""
+        self.owner = new_owner
+        self._record_version()
+
+    def change_status(self, new_status: str) -> None:
+        """Change policy status and track history."""
+        self.status = new_status
+        self._record_version()
 
 
 class PolicyStore:
@@ -19,15 +65,47 @@ class PolicyStore:
     def __init__(self) -> None:
         self.policies: dict[str, Policy] = {}
 
-    def add_policy(self, policy_id: str, title: str, content: str) -> None:
+    def add_policy(
+        self,
+        policy_id: str,
+        title: str,
+        content: str,
+        owner: str,
+        status: str,
+        created_at: datetime | None = None,
+    ) -> None:
         if policy_id in self.policies:
             raise ValueError(f"Policy {policy_id} already exists")
-        self.policies[policy_id] = Policy(policy_id, title, content)
+        self.policies[policy_id] = Policy(
+            policy_id,
+            title,
+            content,
+            owner,
+            status,
+            created_at=created_at,
+        )
 
     def edit_policy(self, policy_id: str, new_content: str) -> None:
         if policy_id not in self.policies:
             raise KeyError(f"Policy {policy_id} not found")
         self.policies[policy_id].update(new_content)
+
+    def mark_policy_reviewed(
+        self, policy_id: str, reviewed_at: datetime | None = None
+    ) -> None:
+        if policy_id not in self.policies:
+            raise KeyError(f"Policy {policy_id} not found")
+        self.policies[policy_id].mark_reviewed(reviewed_at)
+
+    def change_policy_owner(self, policy_id: str, new_owner: str) -> None:
+        if policy_id not in self.policies:
+            raise KeyError(f"Policy {policy_id} not found")
+        self.policies[policy_id].change_owner(new_owner)
+
+    def change_policy_status(self, policy_id: str, new_status: str) -> None:
+        if policy_id not in self.policies:
+            raise KeyError(f"Policy {policy_id} not found")
+        self.policies[policy_id].change_status(new_status)
 
     def delete_policy(self, policy_id: str) -> None:
         if policy_id not in self.policies:

--- a/policy_management/tests/test_policy_store.py
+++ b/policy_management/tests/test_policy_store.py
@@ -1,18 +1,84 @@
+from datetime import datetime
+
 from policy_management.policy_store import PolicyStore
 
 
 def test_add_edit_delete_policy():
     store = PolicyStore()
-    store.add_policy("1", "First", "content v1")
+    created_at = datetime(2024, 1, 1, 12, 0, 0)
+    review_time = datetime(2024, 1, 2, 12, 0, 0)
+    store.add_policy("1", "First", "content v1", "Alice", "Draft", created_at)
 
     policy = store.view_policy("1")
     assert policy.title == "First"
     assert policy.content == "content v1"
+    assert policy.owner == "Alice"
+    assert policy.status == "Draft"
+    assert policy.created_at == created_at
+    assert policy.last_reviewed_at is None
+    assert policy.versions == [
+        {
+            "content": "content v1",
+            "owner": "Alice",
+            "status": "Draft",
+            "created_at": created_at,
+            "last_reviewed_at": None,
+        }
+    ]
 
     store.edit_policy("1", "content v2")
     policy = store.view_policy("1")
     assert policy.content == "content v2"
-    assert policy.versions == ["content v1", "content v2"]
+
+    store.mark_policy_reviewed("1", review_time)
+    policy = store.view_policy("1")
+    assert policy.last_reviewed_at == review_time
+
+    store.change_policy_owner("1", "Bob")
+    policy = store.view_policy("1")
+    assert policy.owner == "Bob"
+
+    store.change_policy_status("1", "Approved")
+    policy = store.view_policy("1")
+    assert policy.status == "Approved"
+
+    assert policy.versions == [
+        {
+            "content": "content v1",
+            "owner": "Alice",
+            "status": "Draft",
+            "created_at": created_at,
+            "last_reviewed_at": None,
+        },
+        {
+            "content": "content v2",
+            "owner": "Alice",
+            "status": "Draft",
+            "created_at": created_at,
+            "last_reviewed_at": None,
+        },
+        {
+            "content": "content v2",
+            "owner": "Alice",
+            "status": "Draft",
+            "created_at": created_at,
+            "last_reviewed_at": review_time,
+        },
+        {
+            "content": "content v2",
+            "owner": "Bob",
+            "status": "Draft",
+            "created_at": created_at,
+            "last_reviewed_at": review_time,
+        },
+        {
+            "content": "content v2",
+            "owner": "Bob",
+            "status": "Approved",
+            "created_at": created_at,
+            "last_reviewed_at": review_time,
+        },
+    ]
 
     store.delete_policy("1")
     assert store.list_policies() == []


### PR DESCRIPTION
## Summary
- add owner, status, and review timestamps to policies and snapshot them in version history
- expose PolicyStore helpers to update policy metadata and initialize timestamps on creation
- expand policy store tests to cover metadata initialization, updates, and history tracking

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946bfc666e0832f9bcdd0c623704e97)