### PR TITLE
Add policy metadata and library features

### DIFF
--- a/policy_management/policy_store.py
+++ b/policy_management/policy_store.py
@@ -1,38 +1,148 @@
-class Policy:
-    """Represents a policy with version history."""
+from datetime import datetime
+from typing import Optional
 
-    def __init__(self, policy_id: str, title: str, content: str):
+
+class Policy:
+    """Represents a policy with version history and management info."""
+
+    def __init__(
+        self,
+        policy_id: str,
+        title: str,
+        content: str,
+        *,
+        owner: Optional[str] = None,
+        status: str = "draft",
+    ) -> None:
         self.policy_id = policy_id
         self.title = title
         self.content = content
-        self.versions = [content]
+        self.owner = owner
+        self.status = status
+        self.created_at = datetime.utcnow()
+        self.last_reviewed_at: Optional[datetime] = None
+        self.versions: list[dict[str, object]] = []
+        self._append_version_record(updated_by=owner, updated_at=self.created_at)
 
-    def update(self, new_content: str) -> None:
-        """Update policy content and track version history."""
-        self.content = new_content
-        self.versions.append(new_content)
+    def _append_version_record(
+        self,
+        *,
+        updated_by: Optional[str],
+        updated_at: datetime,
+    ) -> None:
+        self.versions.append(
+            {
+                "content": self.content,
+                "title": self.title,
+                "updated_at": updated_at,
+                "updated_by": updated_by,
+                "status": self.status,
+                "owner": self.owner,
+                "last_reviewed_at": self.last_reviewed_at,
+            }
+        )
+
+    def update(
+        self,
+        new_content: Optional[str] = None,
+        *,
+        title: Optional[str] = None,
+        updated_by: Optional[str] = None,
+        updated_at: Optional[datetime] = None,
+        owner: Optional[str] = None,
+        status: Optional[str] = None,
+        last_reviewed_at: Optional[datetime] = None,
+    ) -> None:
+        """Update policy details and track version history."""
+
+        if new_content is not None:
+            self.content = new_content
+        if title is not None:
+            self.title = title
+        if owner is not None:
+            self.owner = owner
+        if status is not None:
+            self.status = status
+        if last_reviewed_at is not None:
+            self.last_reviewed_at = last_reviewed_at
+
+        self._append_version_record(
+            updated_by=updated_by,
+            updated_at=updated_at or datetime.utcnow(),
+        )
+
+    def mark_reviewed(self, reviewer: Optional[str] = None, reviewed_at: Optional[datetime] = None) -> None:
+        timestamp = reviewed_at or datetime.utcnow()
+        self.update(updated_by=reviewer, last_reviewed_at=timestamp, updated_at=timestamp)
+
+
+class PolicyLibrary:
+    """Represents a collection of policies."""
+
+    def __init__(self, library_id: str, name: str) -> None:
+        self.library_id = library_id
+        self.name = name
+        self.policy_ids: set[str] = set()
+
+    def add_policy(self, policy_id: str) -> None:
+        self.policy_ids.add(policy_id)
+
+    def remove_policy(self, policy_id: str) -> None:
+        self.policy_ids.discard(policy_id)
 
 
 class PolicyStore:
-    """In-memory store for policies."""
+    """In-memory store for policies and libraries."""
 
     def __init__(self) -> None:
         self.policies: dict[str, Policy] = {}
+        self.libraries: dict[str, PolicyLibrary] = {}
 
-    def add_policy(self, policy_id: str, title: str, content: str) -> None:
+    def add_policy(
+        self,
+        policy_id: str,
+        title: str,
+        content: str,
+        *,
+        owner: Optional[str] = None,
+        status: str = "draft",
+    ) -> None:
         if policy_id in self.policies:
             raise ValueError(f"Policy {policy_id} already exists")
-        self.policies[policy_id] = Policy(policy_id, title, content)
+        self.policies[policy_id] = Policy(
+            policy_id,
+            title,
+            content,
+            owner=owner,
+            status=status,
+        )
 
-    def edit_policy(self, policy_id: str, new_content: str) -> None:
+    def edit_policy(
+        self,
+        policy_id: str,
+        new_content: Optional[str] = None,
+        *,
+        title: Optional[str] = None,
+        updated_by: Optional[str] = None,
+        owner: Optional[str] = None,
+        status: Optional[str] = None,
+    ) -> None:
         if policy_id not in self.policies:
             raise KeyError(f"Policy {policy_id} not found")
-        self.policies[policy_id].update(new_content)
+        self.policies[policy_id].update(
+            new_content,
+            title=title,
+            updated_by=updated_by,
+            owner=owner,
+            status=status,
+        )
 
     def delete_policy(self, policy_id: str) -> None:
         if policy_id not in self.policies:
             raise KeyError(f"Policy {policy_id} not found")
         del self.policies[policy_id]
+        for library in self.libraries.values():
+            library.remove_policy(policy_id)
 
     def view_policy(self, policy_id: str) -> Policy:
         if policy_id not in self.policies:
@@ -41,3 +151,46 @@ class PolicyStore:
 
     def list_policies(self) -> list[Policy]:
         return list(self.policies.values())
+
+    def set_policy_owner(self, policy_id: str, owner: str) -> None:
+        if policy_id not in self.policies:
+            raise KeyError(f"Policy {policy_id} not found")
+        self.policies[policy_id].update(owner=owner)
+
+    def set_policy_status(self, policy_id: str, status: str) -> None:
+        if policy_id not in self.policies:
+            raise KeyError(f"Policy {policy_id} not found")
+        self.policies[policy_id].update(status=status)
+
+    def mark_policy_reviewed(self, policy_id: str, reviewer: Optional[str] = None) -> None:
+        if policy_id not in self.policies:
+            raise KeyError(f"Policy {policy_id} not found")
+        self.policies[policy_id].mark_reviewed(reviewer=reviewer)
+
+    def create_library(self, library_id: str, name: str) -> None:
+        if library_id in self.libraries:
+            raise ValueError(f"Library {library_id} already exists")
+        self.libraries[library_id] = PolicyLibrary(library_id, name)
+
+    def delete_library(self, library_id: str) -> None:
+        if library_id not in self.libraries:
+            raise KeyError(f"Library {library_id} not found")
+        del self.libraries[library_id]
+
+    def add_policy_to_library(self, library_id: str, policy_id: str) -> None:
+        if library_id not in self.libraries:
+            raise KeyError(f"Library {library_id} not found")
+        if policy_id not in self.policies:
+            raise KeyError(f"Policy {policy_id} not found")
+        self.libraries[library_id].add_policy(policy_id)
+
+    def remove_policy_from_library(self, library_id: str, policy_id: str) -> None:
+        if library_id not in self.libraries:
+            raise KeyError(f"Library {library_id} not found")
+        self.libraries[library_id].remove_policy(policy_id)
+
+    def list_policies_in_library(self, library_id: str) -> list[Policy]:
+        if library_id not in self.libraries:
+            raise KeyError(f"Library {library_id} not found")
+        library = self.libraries[library_id]
+        return [self.policies[pid] for pid in library.policy_ids if pid in self.policies]

--- a/policy_management/tests/conftest.py
+++ b/policy_management/tests/conftest.py
@@ -1,0 +1,8 @@
+import sys
+from pathlib import Path
+
+
+# Ensure the repository root is available on sys.path when running tests
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/policy_management/tests/test_policy_store.py
+++ b/policy_management/tests/test_policy_store.py
@@ -1,18 +1,60 @@
+from datetime import datetime
+
 from policy_management.policy_store import PolicyStore
 
 
-def test_add_edit_delete_policy():
+def test_add_edit_delete_policy_with_versions_and_title_updates():
     store = PolicyStore()
-    store.add_policy("1", "First", "content v1")
+    store.add_policy("1", "First", "content v1", owner="alice", status="approved")
 
     policy = store.view_policy("1")
     assert policy.title == "First"
     assert policy.content == "content v1"
+    assert policy.owner == "alice"
+    assert policy.status == "approved"
+    assert policy.versions[0]["title"] == "First"
 
-    store.edit_policy("1", "content v2")
+    store.edit_policy("1", "content v2", title="Updated", updated_by="bob")
     policy = store.view_policy("1")
+    assert policy.title == "Updated"
     assert policy.content == "content v2"
-    assert policy.versions == ["content v1", "content v2"]
+    assert len(policy.versions) == 2
+    assert policy.versions[-1]["updated_by"] == "bob"
+    assert policy.versions[-1]["title"] == "Updated"
+    assert policy.versions[-1]["content"] == "content v2"
 
     store.delete_policy("1")
     assert store.list_policies() == []
+
+
+def test_policy_library_grouping():
+    store = PolicyStore()
+    store.add_policy("1", "Policy A", "A")
+    store.add_policy("2", "Policy B", "B")
+    store.create_library("lib1", "Library One")
+    store.add_policy_to_library("lib1", "1")
+    store.add_policy_to_library("lib1", "2")
+
+    policies_in_library = store.list_policies_in_library("lib1")
+    assert {p.policy_id for p in policies_in_library} == {"1", "2"}
+
+    store.remove_policy_from_library("lib1", "2")
+    policies_in_library = store.list_policies_in_library("lib1")
+    assert {p.policy_id for p in policies_in_library} == {"1"}
+
+
+def test_policy_management_info_updates():
+    store = PolicyStore()
+    store.add_policy("1", "Policy", "content", status="draft")
+
+    store.set_policy_owner("1", "owner1")
+    store.set_policy_status("1", "approved")
+    before_review = datetime.utcnow()
+    store.mark_policy_reviewed("1", reviewer="qa")
+    policy = store.view_policy("1")
+
+    assert policy.owner == "owner1"
+    assert policy.status == "approved"
+    assert policy.last_reviewed_at is not None
+    assert policy.last_reviewed_at >= before_review
+    assert policy.versions[-1]["updated_by"] == "qa"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pytest
+pytest==8.3.3


### PR DESCRIPTION
## Summary
- add policy metadata fields, version records, and support for title updates
- introduce policy libraries with CRUD operations and assignment helpers
- expand tests and helpers to cover metadata and library workflows

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946b3b525bc832f8c88e8f3ae36d62d)